### PR TITLE
chore: add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,50 @@
+# OpenSSF Scorecard - Security scoring and visibility
+# Based on https://github.com/ossf/scorecard-action
+name: OpenSSF Scorecard
+
+on:
+  # Run on changes to main branch
+  push:
+    branches:
+      - main
+  # Weekly scan
+  schedule:
+    - cron: '0 6 * * 0'
+  # Allow manual trigger
+  workflow_dispatch:
+
+# Required permissions for scorecard
+permissions:
+  security-events: write  # Upload SARIF results
+  id-token: write         # For badge generation
+  contents: read
+  actions: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary
Add OpenSSF Scorecard workflow for security scoring and visibility.

## Details
- Runs weekly and on pushes to main branch
- Results published to GitHub Security tab
- Enables security badge for README

🤖 Generated with [Claude Code](https://claude.com/claude-code)