### PR TITLE
fix: use repo root as build context for image scanning

### DIFF
--- a/.github/workflows/image-scanning.yml
+++ b/.github/workflows/image-scanning.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Build image
         run: |
-          docker build -f ${{ matrix.component }}/Dockerfile -t local/${{ matrix.component }}:${{ github.sha }} ${{ matrix.component }}
+          docker build -f ${{ matrix.component }}/Dockerfile -t local/${{ matrix.component }}:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.28.0


### PR DESCRIPTION
## Summary
Fix the image-scanning workflow to use the repo root as build context.

## Details
The Dockerfiles expect files from the repo root (go.mod, api/, cmd/, etc), not the component subdirectory. Changed build context from `${{ matrix.component }}` to `.`.

## Test plan
- [ ] Verify Container Image Scanning workflow passes for all components

🤖 Generated with [Claude Code](https://claude.com/claude-code)