### PR TITLE
🐛 fix: Update Dockerfiles to match actual source structure

### DIFF
--- a/.github/workflows/image-scanning.yml
+++ b/.github/workflows/image-scanning.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Build image
         run: |
-          docker build -t local/${{ matrix.component }}:${{ github.sha }} ${{ matrix.component }}
+          docker build -f ${{ matrix.component }}/Dockerfile -t local/${{ matrix.component }}:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.33.1

--- a/clustermetrics/Dockerfile
+++ b/clustermetrics/Dockerfile
@@ -5,16 +5,16 @@ ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
+COPY clustermetrics/go.mod go.mod
+COPY clustermetrics/go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
 # Copy the go source
-COPY cmd/cluster-metrics/main.go cmd/main.go
-COPY api/ api/
-COPY internal/controller/ internal/controller/
+COPY clustermetrics/cmd/cluster-metrics/main.go cmd/main.go
+COPY clustermetrics/api/ api/
+COPY clustermetrics/internal/controller/ internal/controller/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command

--- a/mc-scheduling/Dockerfile
+++ b/mc-scheduling/Dockerfile
@@ -5,29 +5,34 @@ ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
+COPY mc-scheduling/go.mod mc-scheduling/go.mod
+COPY mc-scheduling/go.sum mc-scheduling/go.sum
+# Copy clustermetrics for local replace directive
+COPY clustermetrics/go.mod clustermetrics/go.mod
+COPY clustermetrics/go.sum clustermetrics/go.sum
+WORKDIR /workspace/mc-scheduling
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
 # Copy the go source
-COPY cmd/main.go cmd/main.go
-COPY api/ api/
-COPY internal/controller/ internal/controller/
+COPY mc-scheduling/cmd/ cmd/
+COPY mc-scheduling/internal/ internal/
+COPY mc-scheduling/pkg/ pkg/
+COPY clustermetrics/ /workspace/clustermetrics/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager ./cmd/mc-scheduler
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/mc-scheduling/manager .
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/shadow-pods/Dockerfile
+++ b/shadow-pods/Dockerfile
@@ -5,23 +5,22 @@ ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
+COPY shadow-pods/go.mod go.mod
+COPY shadow-pods/go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
 # Copy the go source
-COPY cmd/main.go cmd/main.go
-COPY api/ api/
-COPY internal/controller/ internal/controller/
+COPY shadow-pods/cmd/ cmd/
+COPY shadow-pods/internal/ internal/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager ./cmd/shadow-pods
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
## Summary
- Fix shadow-pods Dockerfile: copy entire cmd/ and internal/ directories, build from ./cmd/shadow-pods
- Fix mc-scheduling Dockerfile: copy entire cmd/, internal/, and pkg/ directories, build from ./cmd/mc-scheduler
- Both components had template Dockerfiles that didn't match their actual source layout

## Test plan
- [ ] Verify Container Image Scanning workflow passes for all components

🤖 Generated with [Claude Code](https://claude.com/claude-code)