### PR TITLE
🌱 Bump aquasecurity/trivy-action to v0.35.0

### DIFF
--- a/.github/workflows/image-scanning.yml
+++ b/.github/workflows/image-scanning.yml
@@ -51,7 +51,7 @@ jobs:
           docker build -f ${{ matrix.component }}/Dockerfile -t local/${{ matrix.component }}:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: 'local/${{ matrix.component }}:${{ github.sha }}'
           format: 'sarif'


### PR DESCRIPTION
## Summary
- Upgrades `aquasecurity/trivy-action` to v0.35.0
- Pin by commit hash per repo GHA discipline: `57a97c7e7821a5776cebc9bb87c984fa69cba8f1`

## Related issue(s)
Related: kubestellar/infra#129

## Test plan
- [ ] CI passes on this PR

---
Generated with [Claude Code](https://claude.com/claude-code)